### PR TITLE
updated readme to show correct pip package for yara

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ apt-get install yara
 - Python-YARA
 
 ```
-pip install python-yara
+pip install yara-python
 ```
 
 ## Usage


### PR DESCRIPTION
I was unable to install the pip package for yara. The yara documentation showed the pip package to be yara-python. This is an update for the Readme.